### PR TITLE
fix: Fail build on SNAPSHOT publishing on master

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -222,3 +222,21 @@ semanticRelease {
 }
 
 publish.dependsOn bintrayUpload
+
+prepare.doFirst  {
+  //We get grgit for free because we are using semantic-release
+  if(grgit.branch.getCurrent().name == "master" && version.toString().endsWith('-SNAPSHOT') && project.gradle.startParameter.taskNames.find { it == 'release' }) {
+    println """We are on the master branch, but the version is ending in -SNAPSHOT. The version only gets -SNAPSHOT dropped if:
+      * We are on the master branch
+      * The repo is clean
+      * There is a commit prefixed with 'fix:' or 'feat:' since the last release
+
+      If none of those things happened on the master branch then we will still land in the snapshot version strategy and have a version number with -SNAPSHOT.
+
+      See here for more details:
+
+      https://github.com/tschulte/gradle-semantic-release-plugin
+      """
+      throw new GradleException('Releasing -SNAPSHOT version on master branch')
+  }
+}


### PR DESCRIPTION
Throw an explicit failure for trying to publish a SNAPSHOT. This is intended to also force a release. As a follow up, we should be able to post to oss.jfrog.org, but waiting on group id approval. This would make the conditional deploy irrelevant.