### PR TITLE
Pass excluded tasks along when recursing

### DIFF
--- a/src/main/groovy/com/adtran/ScalaMultiVersionPlugin.groovy
+++ b/src/main/groovy/com/adtran/ScalaMultiVersionPlugin.groovy
@@ -128,7 +128,8 @@ class ScalaMultiVersionPlugin implements Plugin<Project> {
                         startParameter = project.gradle.startParameter.newInstance()
                         startParameter.projectProperties["scalaVersion"] = ver
                         startParameter.projectProperties["recursed"] = true
-                        startParameter.excludedTaskNames = getRunOnceTasks()
+                        startParameter.excludedTaskNames = getRunOnceTasks() +
+                           project.gradle.startParameter.excludedTaskNames
                         tasks = project.gradle.startParameter.taskNames
                     }
                 }

--- a/src/main/groovy/com/adtran/ScalaMultiVersionPlugin.groovy
+++ b/src/main/groovy/com/adtran/ScalaMultiVersionPlugin.groovy
@@ -128,8 +128,7 @@ class ScalaMultiVersionPlugin implements Plugin<Project> {
                         startParameter = project.gradle.startParameter.newInstance()
                         startParameter.projectProperties["scalaVersion"] = ver
                         startParameter.projectProperties["recursed"] = true
-                        startParameter.excludedTaskNames = getRunOnceTasks() +
-                           project.gradle.startParameter.excludedTaskNames
+                        startParameter.excludedTaskNames += getRunOnceTasks()
                         tasks = project.gradle.startParameter.taskNames
                     }
                 }

--- a/src/test/groovy/integration/TestScalaMultiVersionPluginIntegration.groovy
+++ b/src/test/groovy/integration/TestScalaMultiVersionPluginIntegration.groovy
@@ -69,6 +69,20 @@ class TestScalaMultiVersionPlugin extends GroovyTestCase implements SimpleProjec
         assert result.output.contains("t2 2.2.2")
     }
 
+    void testExcludeTaskPassesThrough() {
+        def result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments("t1", "t2", "--exclude-task=t2", "-PscalaVersions=1.1.1,2.2.2")
+            .build()
+        assert result.taskPaths(SUCCESS).toSorted() == [":t1",
+                                                        ":recurseWithScalaVersion_2.2.2",
+                                                        ":codeProject:t1"].sort()
+        assert result.output.contains("t1 1.1.1")
+        assert result.output.contains("t1 2.2.2")
+        assert !result.output.contains("t2 1.1.1")
+        assert !result.output.contains("t2 2.2.2")
+    }
+
     void testDefaultVersion() {
         def result = GradleRunner.create()
             .withProjectDir(projectDir)


### PR DESCRIPTION
Fixes #20 

The added test failed prior to the change. Passes afterward.