### PR TITLE
further disambiguate dynamic buildName with scala version

### DIFF
--- a/src/main/groovy/com/adtran/ScalaMultiVersionPlugin.groovy
+++ b/src/main/groovy/com/adtran/ScalaMultiVersionPlugin.groovy
@@ -135,7 +135,7 @@ class ScalaMultiVersionPlugin implements Plugin<Project> {
                         // workaround name clash issue in Gradle 6+. See:
                         // https://github.com/ADTRAN/gradle-scala-multiversion-plugin/issues/27.
                         if (6 <= project.gradle.gradleVersion.split(Pattern.quote('.'))[0].toInteger() ){
-                            buildName = project.name + ver
+                            buildName = project.name + "_" + ver
                         }
                     }
                 }

--- a/src/main/groovy/com/adtran/ScalaMultiVersionPlugin.groovy
+++ b/src/main/groovy/com/adtran/ScalaMultiVersionPlugin.groovy
@@ -135,7 +135,7 @@ class ScalaMultiVersionPlugin implements Plugin<Project> {
                         // workaround name clash issue in Gradle 6+. See:
                         // https://github.com/ADTRAN/gradle-scala-multiversion-plugin/issues/27.
                         if (6 <= project.gradle.gradleVersion.split(Pattern.quote('.'))[0].toInteger() ){
-                            buildName = project.name
+                            buildName = project.name + ver
                         }
                     }
                 }


### PR DESCRIPTION
- we ran into #27 again when trying to add a 3rd scala version to our `scalaVersions` https://github.com/Workday/warp-core/pull/70
- cross-compiling for 2.11 and 2.12 works without this change, as does cross-compiling for 2.12 and 2.13. somehow cross-compiling for 3 scala versions reintroduces a name conflict like in #27 