### PR TITLE
Optional scala suffix in published artifacts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -224,6 +224,16 @@ syntax. In this case, you need to use the same syntax in the substitution rule::
 
 .. _composite builds: https://docs.gradle.org/current/userguide/composite_builds.html
 
+
+Customized publishing
+=================
+
+By default POM files are modified by adding ``scala_version`` at end of artifactId. User might disable this behaviour by
+setting ``addScalaSuffix=false`` property .
+
+``gradle build -PaddScalaSuffix=false``
+
+
 Known Limitations
 =================
 

--- a/src/main/groovy/com/adtran/ScalaMultiVersionPlugin.groovy
+++ b/src/main/groovy/com/adtran/ScalaMultiVersionPlugin.groovy
@@ -279,7 +279,11 @@ class ScalaMultiVersionPlugin implements Plugin<Project> {
     private void resolvePomDependencies() {
         project.afterEvaluate {
             // for projects using the maven-publish plugin
-            if (project.plugins.hasPlugin("maven-publish")) {
+            Boolean addScalaSuffix = true
+            if (project.ext.has("addScalaSuffix")) {
+                addScalaSuffix = project.ext.addScalaSuffix.toBoolean()
+            }
+            if (project.plugins.hasPlugin("maven-publish") && addScalaSuffix) {
                 project.publishing.publications.withType(MavenPublication) {
                     pom.withXml { resolveMavenPomDependencies(it) }
                     artifactId += project.ext.scalaSuffix

--- a/src/test/groovy/integration/TestScalaMultiVersionPluginIntegration.groovy
+++ b/src/test/groovy/integration/TestScalaMultiVersionPluginIntegration.groovy
@@ -129,6 +129,20 @@ class TestScalaMultiVersionPlugin extends GroovyTestCase implements SimpleProjec
         assert root.artifactId.text() == "codeProject_2.12"
     }
 
+    void testMavenPublishPomWithoutModifications() {
+        def result = GradleRunner.create()
+                .withProjectDir(projectDir)
+                .withArguments("generatePomFileForMavenPublication", "-PscalaVersions=2.12.1", "-PaddScalaSuffix=false")
+                .build()
+        def pomXml = new File(projectDir, "build/publications/maven/pom-default.xml").text
+        assert !pomXml.contains("_%%")
+        assert !pomXml.contains("%scala_version%")
+        def root = new XmlSlurper().parseText(pomXml)
+        assert root.dependencies.'*'.find { it.artifactId == "scala-library" }.version.text() == '2.12.1'
+        assert root.dependencies.'*'.find { it.artifactId == "fake-scala-dep_2.12" } != null
+        assert root.artifactId.text() == "codeProject"
+    }
+
     void testRunOnceTasks() {
         def result = GradleRunner.create()
             .withProjectDir(projectDir)


### PR DESCRIPTION
New flag to optionally resign from adding ``scala_version`` in published artifacts.

My use case:
* repository with conf/yaml/sql files
* Tests in scala are checking correctness of configs against multiple Spark(and Scala versions)
* Published Artifacts contains only conf files and are not scala specific 